### PR TITLE
fix bug with old version laravel

### DIFF
--- a/src/FacebookServiceProvider.php
+++ b/src/FacebookServiceProvider.php
@@ -19,4 +19,11 @@ class FacebookServiceProvider extends ServiceProvider
                 return new Facebook($pageToken);
             });
     }
+
+    /**
+     * Register any package services.
+     */
+    public function register()
+    {
+    }
 }


### PR DESCRIPTION
Bugfix with Laravel 5.1:

``` sh
 [Symfony\Component\Debug\Exception\FatalErrorException]                                                                                                                                                           
  Class NotificationChannels\Facebook\FacebookServiceProvider contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Support\ServiceProvider::register) 
```
