### PR TITLE
Allow specifying the sending facebook page at run time

### DIFF
--- a/src/FacebookChannel.php
+++ b/src/FacebookChannel.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Facebook;
 
+use Illuminate\Container\Container;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\Facebook\Exceptions\CouldNotCreateMessage;
 
@@ -45,7 +46,7 @@ class FacebookChannel
         }
 
         if ($message->senderGiven()) {
-            $this->fb = new Facebook($message->sender);
+            $this->fb = Container::getInstance()->make(Facebook::class, ['token' => $message->sender]);
         }
 
         $this->fb->send($message->toArray());

--- a/src/FacebookChannel.php
+++ b/src/FacebookChannel.php
@@ -44,6 +44,10 @@ class FacebookChannel
             $message->to($to);
         }
 
+        if ($message->senderGiven()) {
+            $this->fb = new Facebook($message->sender);
+        }
+
         $this->fb->send($message->toArray());
     }
 }

--- a/src/FacebookMessage.php
+++ b/src/FacebookMessage.php
@@ -17,6 +17,9 @@ class FacebookMessage implements \JsonSerializable
     /** @var string Recipient's ID. */
     public $recipient;
 
+    /** @var string Sender's Page Token. */
+    public $sender;
+
     /** @var string Notification Text. */
     public $text;
 
@@ -72,6 +75,20 @@ class FacebookMessage implements \JsonSerializable
     public function to($recipient)
     {
         $this->recipient = $recipient;
+
+        return $this;
+    }
+
+    /**
+     * Sender's facebook page token.
+     *
+     * @param $recipient page token of the sender
+     *
+     * @return $this
+     */
+    public function from($sender)
+    {
+        $this->sender = $sender;
 
         return $this;
     }
@@ -172,6 +189,16 @@ class FacebookMessage implements \JsonSerializable
     public function toNotGiven()
     {
         return ! isset($this->recipient);
+    }
+
+    /**
+     * Determine if a custom sender is given.
+     *
+     * @return bool
+     */
+    public function senderGiven()
+    {
+        return isset($this->sender);
     }
 
     /**

--- a/src/FacebookMessage.php
+++ b/src/FacebookMessage.php
@@ -74,7 +74,7 @@ class FacebookMessage implements \JsonSerializable
      */
     public function to($recipient)
     {
-        $this->recipient = $recipient;
+        $this->recipient = is_array($recipient) ? $recipient : ['id' => $recipient];
 
         return $this;
     }

--- a/tests/FacebookChannelTest.php
+++ b/tests/FacebookChannelTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace NotificationChannels\Facebook\Test;
+
+use GuzzleHttp\Client as HttpClient;
+use Illuminate\Container\Container;
+use Illuminate\Notifications\Notification;
+use Mockery;
+use NotificationChannels\Facebook\FacebookChannel;
+use NotificationChannels\Facebook\FacebookMessage;
+
+class FacebookChannelTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function you_can_swap_the_underlying_facebook_instance_with_a_from_parameter()
+    {
+
+        $message = FacebookMessage::create('my text')->to('12345')->from('abc123');
+        $mock_notification = Mockery::mock(Notification::class, function ($m) use ($message) {
+            $m->shouldReceive('toFacebook')->with('notifiable')->andReturn($message);
+        });
+        $http_client_spy = Mockery::spy(HttpClient::class);
+        Container::getInstance()->instance(HttpClient::class, $http_client_spy);
+
+        Container::getInstance()->make(FacebookChannel::class, [])->send('notifiable', $mock_notification);
+
+        $http_client_spy->shouldHaveReceived('request')->with('POST', Mockery::on(function ($arg) {
+            return ends_with($arg, 'abc123');
+        }), Mockery::any());
+    }
+}

--- a/tests/FacebookChannelTest.php
+++ b/tests/FacebookChannelTest.php
@@ -2,10 +2,10 @@
 
 namespace NotificationChannels\Facebook\Test;
 
-use GuzzleHttp\Client as HttpClient;
-use Illuminate\Container\Container;
-use Illuminate\Notifications\Notification;
 use Mockery;
+use Illuminate\Container\Container;
+use GuzzleHttp\Client as HttpClient;
+use Illuminate\Notifications\Notification;
 use NotificationChannels\Facebook\FacebookChannel;
 use NotificationChannels\Facebook\FacebookMessage;
 
@@ -14,7 +14,6 @@ class FacebookChannelTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function you_can_swap_the_underlying_facebook_instance_with_a_from_parameter()
     {
-
         $message = FacebookMessage::create('my text')->to('12345')->from('abc123');
         $mock_notification = Mockery::mock(Notification::class, function ($m) use ($message) {
             $m->shouldReceive('toFacebook')->with('notifiable')->andReturn($message);

--- a/tests/FacebookMessageTest.php
+++ b/tests/FacebookMessageTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NotificationChannels\Facebook\Test;
+
+use NotificationChannels\Facebook\FacebookMessage;
+
+class FacebookMessageTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_sets_recipient_in_a_backwards_compatible_way()
+    {
+        $this->assertEquals(['id' => 'abc123'], (new FacebookMessage)->to('abc123')->recipient);
+
+        $this->assertEquals(['id' => 'abc123'], (new FacebookMessage)->to(['id' => 'abc123'])->recipient);
+    }
+}


### PR DESCRIPTION
This PR allows specifying a `from` param on the facebook message so that a notification channel can decide at run time which facebook page to send from.

It also fixes a major bug where the recipient id wasn't passed in the manner that facebook was expecting. I would normally split these into separate PRs but since I'm currently using this fork, I just included them in one. 

I tried to generally match the coding style of the project and added tests for the code I changed. 

Finally, I'm going to be using this package in a production system so if the current maintainer would like some help maintaining this repo and adding the missing tests, I'd be happy to pitch in. 