### PR TITLE
added ability to send appsecret_proof with request

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Next we need to add this token to our Laravel configurations. Create a new Faceb
     
     // Optional - Omit this if you want to use default version.
     'version' => env('FACEBOOK_GRAPH_API_VERSION', '4.0')
+    
+    // Optional - If set, the appsecret_proof will be send to verify your page-token
+    'app-secret' => env('FACEBOOK_APP_SECRET', '')
 ],
 ...
 ```

--- a/src/Facebook.php
+++ b/src/Facebook.php
@@ -20,6 +20,9 @@ class Facebook
     /** @var string|null Page Token. */
     protected $token;
 
+    /** @var string|null App Secret */
+    protected $secret;
+
     /** @var string Default Graph API Version */
     protected $graphApiVersion = '4.0';
 
@@ -44,6 +47,20 @@ class Facebook
     public function setGraphApiVersion($graphApiVersion): self
     {
         $this->graphApiVersion = $graphApiVersion;
+
+        return $this;
+    }
+
+    /**
+     * Set App Secret to generate appsecret_proof.
+     *
+     * @param string $secret
+     *
+     * @return Facebook
+     */
+    public function setSecret($secret = null): self
+    {
+        $this->secret = $secret;
 
         return $this;
     }
@@ -116,6 +133,12 @@ class Facebook
         }
 
         $url = "https://graph.facebook.com/v{$this->graphApiVersion}/{$endpoint}?access_token={$this->token}";
+
+        if($this->secret) {
+            $appsecret_proof = hash_hmac('sha256', $this->token, $this->secret);
+
+            $url .= "&appsecret_proof={$appsecret_proof}";
+        }
 
         try {
             return $this->httpClient()->request($method, $url, $options);

--- a/src/Facebook.php
+++ b/src/Facebook.php
@@ -134,7 +134,7 @@ class Facebook
 
         $url = "https://graph.facebook.com/v{$this->graphApiVersion}/{$endpoint}?access_token={$this->token}";
 
-        if($this->secret) {
+        if ($this->secret) {
             $appsecret_proof = hash_hmac('sha256', $this->token, $this->secret);
 
             $url .= "&appsecret_proof={$appsecret_proof}";

--- a/src/FacebookServiceProvider.php
+++ b/src/FacebookServiceProvider.php
@@ -19,7 +19,9 @@ class FacebookServiceProvider extends ServiceProvider
             ->give(static function () {
                 $facebook = new Facebook(config('services.facebook.page-token'));
 
-                return $facebook->setGraphApiVersion(config('services.facebook.version', '4.0'));
+                return $facebook
+                    ->setGraphApiVersion(config('services.facebook.version', '4.0'))
+                    ->setSecret(config('services.facebook.app-secret'));
             });
     }
 }


### PR DESCRIPTION
This PR adds the ability add an `appsecret_proof` to the request as discussed [here](https://github.com/laravel-notification-channels/facebook/issues/43).

Adding the Apps secret is not required. If the config is empty, no secret is send.

