### PR TITLE
Add support for string payload to postback type of button

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ php:
     - 7.2
     - 7.3
     - 7.4
-    
+    - 8.0
+
 env:
     matrix:
         - COMPOSER_FLAGS="--prefer-lowest"

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -122,18 +122,18 @@ class Button implements JsonSerializable
     }
 
     /**
-     * @param  array  $postback
+     * @param  $postback
      *
-     * @throws CouldNotCreateButton
      * @return $this
+     * @throws CouldNotCreateButton|\JsonException
      */
-    public function postback(array $postback): self
+    public function postback($postback): self
     {
         if (blank($postback)) {
             throw CouldNotCreateButton::postbackNotProvided();
         }
 
-        $this->payload['payload'] = json_encode($postback);
+        $this->payload['payload'] = is_string($postback) ? $postback : json_encode($postback, JSON_THROW_ON_ERROR);
         $this->isTypePostback();
 
         return $this;

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -100,7 +100,7 @@ class Card implements JsonSerializable
     public function default(string $url): self
     {
         $this->payload['default_action']['type'] = 'web_url';
-        $this->payload['default_action']['url'] = 'url';
+        $this->payload['default_action']['url'] = $url;
         $this->payload['default_action']['webview_height_ratio'] = 'tall';
 
         return $this;

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -91,6 +91,23 @@ class Card implements JsonSerializable
     }
 
     /**
+     * Set Card default action
+     *
+     * @param  string  $url
+     *
+     * @return $this
+     */
+    public function default(string $url): self
+    {
+        $this->payload['default_action']['type'] = 'web_url';
+        $this->payload['default_action']['url'] = 'url';
+        $this->payload['default_action']['webview_height_ratio'] = 'tall';
+
+        return $this;
+    }
+
+
+    /**
      * Set Card Subtitle.
      *
      * @param  string  $subtitle

--- a/src/FacebookMessage.php
+++ b/src/FacebookMessage.php
@@ -50,6 +50,9 @@ class FacebookMessage implements JsonSerializable
     /** @var string Message tag used with messaging type MESSAGE_TAG */
     protected $messageTag;
 
+    /** @var string */
+    protected $imageAspectRatio = 'square';
+
     /**
      * @param  string  $text
      *
@@ -373,6 +376,7 @@ class FacebookMessage implements JsonSerializable
         $message['notification_type'] = $this->notificationType;
         $message['message']['attachment']['type'] = 'template';
         $message['message']['attachment']['payload']['template_type'] = 'generic';
+        $message['message']['attachment']['payload']['image_aspect_ratio'] = $this->imageAspectRatio;
         $message['message']['attachment']['payload']['elements'] = $this->cards;
         $message['messaging_type'] = $this->messagingType;
 


### PR DESCRIPTION
According to [Postback Button Reference](https://developers.facebook.com/docs/messenger-platform/reference/buttons/postback) payload can be simple string