### PR TITLE
Add Image aspect ratio helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ public function routeNotificationForFacebook()
 - `buttons($buttons = [])`: (array) An array of "Call to Action" buttons (Created using `NotificationChannels\Facebook\Components\Button::create()`). You can add up to 3 buttons of one of the following types: `web_url`, `postback` or `phone_number`. See Button methods below for more details.
 - `cards($cards = [])`: (array) An array of item cards to be displayed in a carousel (Created using `NotificationChannels\Facebook\Components\Card::create()`). You can add up to 10 cards. See Card methods below for more details.
 - `notificationType('')`: (string) Push Notification type: `REGULAR` will emit a sound/vibration and a phone notification; `SILENT_PUSH` will just emit a phone notification, `NO_PUSH` will not emit either. You can make use of `NotificationType::REGULAR`, `NotificationType::SILENT_PUSH` and `NotificationType::NO_PUSH` to make it easier to work with the type. This is an optional method, defaults to `REGULAR` type.
+- `imageAspectRatio('')`: (string) Image Aspect Ratio if Card with `image_url` present. You can use of `ImageAspectRatioType::SQUARE` or  `ImageAspectRatioType::HORIZONTAL`. This is an optional method, defaults to `ImageAspectRatioType::HORIZONTAL` aspect ratio (image should be 1.91:1).
 - `isTypeRegular()`: Helper method to create a notification type: `REGULAR`.
 - `isTypeSilentPush()`: Helper method to create a notification type: `SILENT_PUSH`.
 - `isTypeNoPush()`: Helper method to create a notification type: `NO_PUSH`.

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -79,7 +79,7 @@ class Card implements JsonSerializable
     /**
      * Set Card Image Url.
      *
-     * @param  string  $imageUrl  Image ratio should be 1.91:1
+     * @param  string  $imageUrl  Default image ratio is 1.91:1
      *
      * @return $this
      */

--- a/src/Enums/ImageAspectRatioType.php
+++ b/src/Enums/ImageAspectRatioType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NotificationChannels\Facebook\Enums;
+
+/**
+ * Class ImageAspectRatioType.
+ *
+ * The aspect ratio used to render images specified by element.image_url
+ *
+ * @see https://developers.facebook.com/docs/messenger-platform/reference/templates/generic#payload
+ */
+class ImageAspectRatioType
+{
+    /**
+     * Aspect ratio of image should be 1.91:1
+     */
+    public const HORIZONTAL = 'horizontal';
+    /**
+     * Aspect ratio of image should be 1:1
+     */
+    public const SQUARE = 'square';
+}

--- a/src/Enums/ImageAspectRatioType.php
+++ b/src/Enums/ImageAspectRatioType.php
@@ -12,11 +12,11 @@ namespace NotificationChannels\Facebook\Enums;
 class ImageAspectRatioType
 {
     /**
-     * Aspect ratio of image should be 1.91:1
+     * Aspect ratio of image should be 1.91:1.
      */
     public const HORIZONTAL = 'horizontal';
     /**
-     * Aspect ratio of image should be 1:1
+     * Aspect ratio of image should be 1:1.
      */
     public const SQUARE = 'square';
 }

--- a/src/Exceptions/CouldNotCreateMessage.php
+++ b/src/Exceptions/CouldNotCreateMessage.php
@@ -20,6 +20,16 @@ class CouldNotCreateMessage extends Exception
     }
 
     /**
+     * Thrown when invalid image aspect ratio provided.
+     *
+     * @return static
+     */
+    public static function invalidImageAspectRatio(): self
+    {
+        return new static('Image Aspect Ratio provided is invalid.');
+    }
+
+    /**
      * Thrown when invalid notification type provided.
      *
      * @return static

--- a/src/FacebookMessage.php
+++ b/src/FacebookMessage.php
@@ -50,6 +50,9 @@ class FacebookMessage implements JsonSerializable
     /** @var string Message tag used with messaging type MESSAGE_TAG */
     protected $messageTag;
 
+    /** @var string */
+    protected $imageAspectRatio = 'square';
+
     /**
      * @param  string  $text
      *
@@ -373,6 +376,7 @@ class FacebookMessage implements JsonSerializable
         $message['notification_type'] = $this->notificationType;
         $message['message']['attachment']['type'] = 'template';
         $message['message']['attachment']['payload']['template_type'] = 'generic';
+        $message['message']['attachment']['payload']['image_aspect_ratio'] = $this->imageAspectRatio;
         $message['message']['attachment']['payload']['elements'] = $this->cards;
         $message['messaging_type'] = $this->messagingType;
 


### PR DESCRIPTION
Add optional helper `imageAspectRatio(…)` to FacebookMessenger to set image_aspect_ratio (see [Facebook Documentation](https://developers.facebook.com/docs/messenger-platform/reference/templates/generic#payload))