### PR TITLE
Add thread_key recipient type to support workplace group chats

### DIFF
--- a/src/Enums/RecipientType.php
+++ b/src/Enums/RecipientType.php
@@ -12,4 +12,5 @@ class RecipientType
     public const USER_REF = 'user_ref';
     public const POST_ID = 'post_id';
     public const COMMENT_ID = 'comment_id';
+    public const THREAD_KEY = 'thread_key';
 }


### PR DESCRIPTION
We currently have a bot connected to our Facebook Workplace. We would like to send some notifications to a group chat.

This package is already suitable to support this only the recipient type: `thread_key` needs to be added.

**Facebook Documentation**

- https://developers.facebook.com/docs/workplace/bots/

Example for posting to an existing thread from the docs:
```
POST /me/messages
{
  "recipient": {
    "thread_key": <thread_id>
  },
  "message": <message_payload>
}
```

